### PR TITLE
Handle exception thrown when loading --map arg

### DIFF
--- a/Apps/Extract/Program.cs
+++ b/Apps/Extract/Program.cs
@@ -253,8 +253,15 @@ namespace Extract
 
                 if (_extractMapData)
                 {
-                    LoadXML("ItemsIgnore.xml");
-                    LoadXML("ItemsReplace.xml");
+                    try
+                    {
+                        LoadXML("ItemsIgnore.xml");
+                        LoadXML("ItemsReplace.xml");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex);
+                    }
                 }
 
                 if (_extractItemData)


### PR DESCRIPTION
Handle exception thrown from LoadXml as ItemsIgnore and ItemsReplace isn't mandatory for extracing the map
Fix #36 