### PR TITLE
Add new packets related to character auctions

### DIFF
--- a/TibiaAPI/Constants/Enums.cs
+++ b/TibiaAPI/Constants/Enums.cs
@@ -346,6 +346,7 @@
         RotateSouth = 0x71,
         RotateWest = 0x72,
         Teleport = 0x73,
+        CharacterTradeConfigurationAction = 0x76,
         EquipObject = 0x77,
         MoveObject = 0x78,
         LookNpcTrade = 0x79,
@@ -466,6 +467,7 @@
     {
         Invalid = 0x00,
         CreatureData = 0x03,
+        SessionDumpStart = 0x04,
         PendingStateEntered = 0x0A,
         ReadyForSecondaryConnection = 0x0B,
         WorldEntered = 0x0F,
@@ -513,6 +515,7 @@
         OwnOffer = 0x7D,
         CounterOffer = 0x7E,
         CloseTrade = 0x7F,
+        CharacterTradeConfiguration = 0x80,
         Ambiente = 0x82,
         GraphicalEffects = 0x83,
         RemoveGraphicalEffect = 0x84,

--- a/TibiaAPI/Network/ClientPacket.cs
+++ b/TibiaAPI/Network/ClientPacket.cs
@@ -74,6 +74,8 @@ namespace OXGaming.TibiaAPI.Network
                     return new ClientPackets.RotateWest(client);
                 case ClientPacketType.Teleport:
                     return new ClientPackets.Teleport(client);
+                case ClientPacketType.CharacterTradeConfigurationAction:
+                    return new ClientPackets.CharacterTradeConfigurationAction(client);
                 case ClientPacketType.EquipObject:
                     return new ClientPackets.EquipObject(client);
                 case ClientPacketType.MoveObject:

--- a/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
+++ b/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
@@ -51,9 +51,9 @@ namespace OXGaming.TibiaAPI.Network.ClientPackets
             {
                 StartingBid = message.ReadUInt32();
                 AuctionEnd = message.ReadUInt32();
-                Unknown1 = message.ReadByte();
-                Unknown2 = message.ReadByte();
-                Unknown3 = message.ReadByte();
+                Unknown1 = message.ReadByte(); // 00
+                Unknown2 = message.ReadByte(); // 00
+                Unknown3 = message.ReadByte(); // 00
             }
         }
 

--- a/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
+++ b/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
@@ -52,9 +52,13 @@ namespace OXGaming.TibiaAPI.Network.ClientPackets
             {
                 StartingBid = message.ReadUInt32();
                 AuctionEnd = message.ReadUInt32();
-                Unknown1 = message.ReadByte(); // 00
-                Unknown2 = message.ReadByte(); // 00
-                Unknown3 = message.ReadByte(); // 00
+                Unknown1 = message.ReadByte(); // 00, 01
+                Unknown2 = message.ReadByte(); // 00, 1B
+                Unknown3 = message.ReadByte(); // 00, 01
+                if (Unknown3 == 1)
+                {
+                    message.ReadBytes(4); // 00 01 0C 00
+                }
             }
         }
 

--- a/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
+++ b/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using OXGaming.TibiaAPI.Constants;
 
@@ -61,6 +62,37 @@ namespace OXGaming.TibiaAPI.Network.ClientPackets
         {
             message.Write((byte)ClientPacketType.CharacterTradeConfigurationAction);
             message.Write(Type);
+            if (Type == 2) // Review
+            {
+                message.Write(StartingBid);
+                message.Write(AuctionEnd);
+                var count = Math.Min(DisplayItemIds.Count, byte.MaxValue);
+                message.Write((byte)count);
+                for (var i = 0; i < count; i++)
+                {
+                    message.Write(DisplayItemIds[i]);
+                }
+                count = Math.Min(SelectedStoreItemIds.Count, byte.MaxValue);
+                message.Write((byte)count);
+                for (var i = 0; i < count; i++)
+                {
+                    message.Write(SelectedStoreItemIds[i]);
+                }
+                count = Math.Min(SelectedSalesArgumentIds.Count, byte.MaxValue);
+                message.Write((byte)count);
+                for (var i = 0; i < count; i++)
+                {
+                    message.Write(SelectedSalesArgumentIds[i]);
+                }
+            }
+            else if (Type == 3) // Confirm
+            {
+                message.Write(StartingBid);
+                message.Write(AuctionEnd);
+                message.Write(Unknown1);
+                message.Write(Unknown2);
+                message.Write(Unknown3);
+            }
         }
     }
 }

--- a/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
+++ b/TibiaAPI/Network/ClientPackets/CharacterTradeConfigurationAction.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+
+using OXGaming.TibiaAPI.Constants;
+
+namespace OXGaming.TibiaAPI.Network.ClientPackets
+{
+    public class CharacterTradeConfigurationAction : ClientPacket
+    {
+        public List<ushort> DisplayItemIds { get; } = new List<ushort>();
+        public List<ushort> SelectedSalesArgumentIds { get; } = new List<ushort>();
+        public List<ushort> SelectedStoreItemIds { get; } = new List<ushort>();
+
+        public uint AuctionEnd { get; set; }
+        public uint StartingBid { get; set; }
+
+        public byte Type { get; set; }
+        public byte Unknown1 { get; set; }
+        public byte Unknown2 { get; set; }
+        public byte Unknown3 { get; set; }
+
+        public CharacterTradeConfigurationAction(Client client)
+        {
+            Client = client;
+            PacketType = ClientPacketType.CharacterTradeConfigurationAction;
+        }
+
+        public override void ParseFromNetworkMessage(NetworkMessage message)
+        {
+            Type = message.ReadByte();
+            if (Type == 2) // Review
+            {
+                StartingBid = message.ReadUInt32();
+                AuctionEnd = message.ReadUInt32();
+                DisplayItemIds.Capacity = message.ReadByte();
+                for (var i = 0; i < DisplayItemIds.Capacity; i++)
+                {
+                    DisplayItemIds.Add(message.ReadUInt16());
+                }
+                SelectedStoreItemIds.Capacity = message.ReadByte();
+                for (var i = 0; i < SelectedStoreItemIds.Capacity; i++)
+                {
+                    SelectedStoreItemIds.Add(message.ReadUInt16());
+                }
+                SelectedSalesArgumentIds.Capacity = message.ReadByte();
+                for (var i = 0; i < SelectedSalesArgumentIds.Capacity; i++)
+                {
+                    SelectedSalesArgumentIds.Add(message.ReadUInt16());
+                }
+            }
+            else if (Type == 3) // Confirm
+            {
+                StartingBid = message.ReadUInt32();
+                AuctionEnd = message.ReadUInt32();
+                Unknown1 = message.ReadByte();
+                Unknown2 = message.ReadByte();
+                Unknown3 = message.ReadByte();
+            }
+        }
+
+        public override void AppendToNetworkMessage(NetworkMessage message)
+        {
+            message.Write((byte)ClientPacketType.CharacterTradeConfigurationAction);
+            message.Write(Type);
+        }
+    }
+}

--- a/TibiaAPI/Network/Communication.cs
+++ b/TibiaAPI/Network/Communication.cs
@@ -42,6 +42,7 @@ namespace OXGaming.TibiaAPI.Network
         public event ReceivedPacketEventHandler OnReceivedClientRotateSouthPacket;
         public event ReceivedPacketEventHandler OnReceivedClientRotateWestPacket;
         public event ReceivedPacketEventHandler OnReceivedClientTeleportPacket;
+        public event ReceivedPacketEventHandler OnReceivedClientCharacterTradeConfigurationActionPacket;
         public event ReceivedPacketEventHandler OnReceivedClientEquipObjectPacket;
         public event ReceivedPacketEventHandler OnReceivedClientMoveObjectPacket;
         public event ReceivedPacketEventHandler OnReceivedClientLookNpcTradePacket;
@@ -158,6 +159,7 @@ namespace OXGaming.TibiaAPI.Network
         public event ReceivedPacketEventHandler OnReceivedClientGetTransactionHistoryPacket;
 
         public event ReceivedPacketEventHandler OnReceivedServerCreatureDataPacket;
+        public event ReceivedPacketEventHandler OnReceivedServerSessionDumpStartPacket;
         public event ReceivedPacketEventHandler OnReceivedServerPendingStateEnteredPacket;
         public event ReceivedPacketEventHandler OnReceivedServerReadyForSecondaryConnectionPacket;
         public event ReceivedPacketEventHandler OnReceivedServerWorldEnteredPacket;
@@ -204,6 +206,7 @@ namespace OXGaming.TibiaAPI.Network
         public event ReceivedPacketEventHandler OnReceivedServerOwnOfferPacket;
         public event ReceivedPacketEventHandler OnReceivedServerCounterOfferPacket;
         public event ReceivedPacketEventHandler OnReceivedServerCloseTradePacket;
+        public event ReceivedPacketEventHandler OnReceivedServerCharacterTradeConfigurationPacket;
         public event ReceivedPacketEventHandler OnReceivedServerAmbientePacket;
         public event ReceivedPacketEventHandler OnReceivedServerGraphicalEffectsPacket;
         public event ReceivedPacketEventHandler OnReceivedServerRemoveGraphicalEffectPacket;
@@ -463,6 +466,9 @@ namespace OXGaming.TibiaAPI.Network
                             break;
                         case ClientPacketType.Teleport:
                             packet.Forward = OnReceivedClientTeleportPacket?.Invoke(packet) ?? true;
+                            break;
+                        case ClientPacketType.CharacterTradeConfigurationAction:
+                            packet.Forward = OnReceivedClientCharacterTradeConfigurationActionPacket?.Invoke(packet) ?? true;
                             break;
                         case ClientPacketType.EquipObject:
                             packet.Forward = OnReceivedClientEquipObjectPacket?.Invoke(packet) ?? true;
@@ -885,6 +891,9 @@ namespace OXGaming.TibiaAPI.Network
                         case ServerPacketType.CreatureData:
                             packet.Forward = OnReceivedServerCreatureDataPacket?.Invoke(packet) ?? true;
                             break;
+                        case ServerPacketType.SessionDumpStart:
+                            packet.Forward = OnReceivedServerSessionDumpStartPacket?.Invoke(packet) ?? true;
+                            break;
                         case ServerPacketType.PendingStateEntered:
                             packet.Forward = OnReceivedServerPendingStateEnteredPacket?.Invoke(packet) ?? true;
                             break;
@@ -1033,6 +1042,9 @@ namespace OXGaming.TibiaAPI.Network
                             break;
                         case ServerPacketType.CloseTrade:
                             packet.Forward = OnReceivedServerCloseTradePacket?.Invoke(packet) ?? true;
+                            break;
+                        case ServerPacketType.CharacterTradeConfiguration:
+                            packet.Forward = OnReceivedServerCharacterTradeConfigurationPacket?.Invoke(packet) ?? true;
                             break;
                         case ServerPacketType.Ambiente:
                             packet.Forward = OnReceivedServerAmbientePacket?.Invoke(packet) ?? true;

--- a/TibiaAPI/Network/ServerPacket.cs
+++ b/TibiaAPI/Network/ServerPacket.cs
@@ -16,6 +16,8 @@ namespace OXGaming.TibiaAPI.Network
                     return new ServerPacket();
                 case ServerPacketType.CreatureData:
                     return new ServerPackets.CreatureData(client);
+                case ServerPacketType.SessionDumpStart:
+                    return new ServerPackets.SessionDumpStart(client);
                 case ServerPacketType.PendingStateEntered:
                     return new ServerPackets.PendingStateEntered(client);
                 case ServerPacketType.ReadyForSecondaryConnection:
@@ -113,6 +115,8 @@ namespace OXGaming.TibiaAPI.Network
                     return new ServerPackets.CounterOffer(client);
                 case ServerPacketType.CloseTrade:
                     return new ServerPackets.CloseTrade(client);
+                case ServerPacketType.CharacterTradeConfiguration:
+                    return new ServerPackets.CharacterTradeConfiguration(client);
                 case ServerPacketType.Ambiente:
                     return new ServerPackets.Ambiente(client);
                 case ServerPacketType.GraphicalEffects:

--- a/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
+++ b/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
@@ -148,7 +148,9 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
             else if (Type == 4)
             {
                 message.Write(AuctionFee);
-                message.Write(Unknown1);
+                // Changing this to 1 crashed the client, so it could be a boolean,
+                // or some other identifier, and the client expects more data if not 0.
+                message.Write(Unknown1); // 00
             }
         }
     }

--- a/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
+++ b/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
@@ -88,7 +88,9 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
             else if (Type == 4)
             {
                 AuctionFee = message.ReadUInt16();
-                Unknown1 = message.ReadByte();
+                // Changing this to 1 crashed the client, so it could be a boolean,
+                // or some other identifier, and the client expects more data if not 0.
+                Unknown1 = message.ReadByte(); // 00
             }
         }
 

--- a/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
+++ b/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
@@ -94,7 +94,6 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
 
         public override void AppendToNetworkMessage(NetworkMessage message)
         {
-            // TODO
             message.Write((byte)ServerPacketType.CharacterTradeConfiguration);
             message.Write(Type);
             if (Type == 0)

--- a/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
+++ b/TibiaAPI/Network/ServerPackets/CharacterTradeConfiguration.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+
+using OXGaming.TibiaAPI.Constants;
+
+namespace OXGaming.TibiaAPI.Network.ServerPackets
+{
+    public class CharacterTradeConfiguration : ServerPacket
+    {
+        public List<(ushort Id, uint Count)> Items { get; } =
+            new List<(ushort Id, uint Count)>();
+
+        public List<(string Requirement, bool IsSatisfied)> Requirements { get; } =
+            new List<(string Requirement, bool IsSatisfied)>();
+
+        public List<(byte Id, string Title, List<(ushort Id, string Description)> Entries)> SalesArguments { get; } =
+            new List<(byte Id, string Title, List<(ushort Id, string Description)> Entries)>();
+
+        public string CharacterName { get; set; }
+
+        public uint AuctionEnd { get; set; }
+        public uint AuctionStart { get; set; }
+
+        public ushort AuctionFee { get; set; }
+        public ushort Level { get; set; }
+        public ushort StartingBid { get; set; }
+
+        public byte Sex { get; set; }
+        public byte Type { get; set; }
+        public byte VocationId { get; set; }
+
+        public byte Unknown1 { get; set; }
+
+        public CharacterTradeConfiguration(Client client)
+        {
+            Client = client;
+            PacketType = ServerPacketType.CharacterTradeConfiguration;
+        }
+
+        public override void ParseFromNetworkMessage(NetworkMessage message)
+        {
+            // TODO
+            Type = message.ReadByte();
+            if (Type == 0)
+            {
+                CharacterName = message.ReadString();
+                Level = message.ReadUInt16();
+                VocationId = message.ReadByte();
+                Sex = message.ReadByte();
+                AuctionStart = message.ReadUInt32();
+                AuctionEnd = message.ReadUInt32();
+                StartingBid = message.ReadUInt16();
+                Requirements.Capacity = message.ReadByte();
+                for (var i = 0; i < Requirements.Capacity; i++)
+                {
+                    var requirement = message.ReadString();
+                    var isSatisfied = message.ReadBool();
+                    Requirements.Add((requirement, isSatisfied));
+                }
+            }
+            else if (Type == 1 || Type == 2) // 1 = inventory/depot items, 2 = store inbox items
+            {
+                Items.Capacity = message.ReadUInt16();
+                for (var i = 0; i < Items.Capacity; i++)
+                {
+                    var id = message.ReadUInt16();
+                    var count = message.ReadUInt32();
+                    Items.Add((id, count));
+                }
+            }
+            else if (Type == 3)
+            {
+                SalesArguments.Capacity = message.ReadByte();
+                for (var i = 0; i < SalesArguments.Capacity; i++)
+                {
+                    var id = message.ReadByte();
+                    var title = message.ReadString();
+                    var entries = new List<(ushort, string)>(message.ReadUInt16());
+                    for (var j = 0; j < entries.Capacity; j++)
+                    {
+                        var index = message.ReadUInt16();
+                        var description = message.ReadString();
+                        entries.Add((index, description));
+                    }
+                    SalesArguments.Add((id, title, entries));
+                }
+            }
+            else if (Type == 4)
+            {
+                AuctionFee = message.ReadUInt16();
+                Unknown1 = message.ReadByte();
+            }
+        }
+
+        public override void AppendToNetworkMessage(NetworkMessage message)
+        {
+            // TODO
+            message.Write((byte)ServerPacketType.CharacterTradeConfiguration);
+            message.Write(Type);
+            if (Type == 0)
+            {
+                message.Write(CharacterName);
+                message.Write(Level);
+                message.Write(VocationId);
+                message.Write(Sex);
+                message.Write(AuctionStart);
+                message.Write(AuctionEnd);
+                message.Write(StartingBid);
+                var count = Math.Min(Requirements.Count, byte.MaxValue);
+                message.Write((byte)count);
+                for (var i = 0; i < count; i++)
+                {
+                    var (Requirement, IsSatisfied) = Requirements[i];
+                    message.Write(Requirement);
+                    message.Write(IsSatisfied);
+                }
+            }
+            else if (Type == 1 || Type == 2) // 1 = inventory/depot items, 2 = store inbox items
+            {
+                var count = Math.Min(Items.Count, ushort.MaxValue);
+                message.Write((ushort)count);
+                for (var i = 0; i < count; i++)
+                {
+                    var (Id, Count) = Items[i];
+                    message.Write(Id);
+                    message.Write(Count);
+                }
+            }
+            else if (Type == 3)
+            {
+                var count = Math.Min(SalesArguments.Count, byte.MaxValue);
+                message.Write((byte)count);
+                for (var i = 0; i < count; i++)
+                {
+                    var (Id, Title, Entries) = SalesArguments[i];
+                    message.Write(Id);
+                    message.Write(Title);
+                    var subCount = Math.Min(Entries.Count, ushort.MaxValue);
+                    message.Write((ushort)subCount);
+                    for (var j = 0; j < subCount; j++)
+                    {
+                        var (Index, Description) = Entries[j];
+                        message.Write(Index);
+                        message.Write(Description);
+                    }
+                }
+            }
+            else if (Type == 4)
+            {
+                message.Write(AuctionFee);
+                message.Write(Unknown1);
+            }
+        }
+    }
+}

--- a/TibiaAPI/Network/ServerPackets/CreditBalance.cs
+++ b/TibiaAPI/Network/ServerPackets/CreditBalance.cs
@@ -7,6 +7,7 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
         public int TransferableTibiaCoins { get; set; }
         public int TotalTibiaCoins { get; set; }
         public int TournamentCoins { get; set; }
+        public int Unknown { get; set; }
 
         public bool UpdateCreditBalance { get; set; }
 
@@ -23,6 +24,10 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
             {
                 TotalTibiaCoins = message.ReadInt32();
                 TransferableTibiaCoins = message.ReadInt32();
+                if (Client.VersionNumber >= 125010109)
+                {
+                    Unknown = message.ReadInt32();
+                }
                 if (Client.VersionNumber >= 12158493)
                 {
                     TournamentCoins = message.ReadInt32();
@@ -38,6 +43,10 @@ namespace OXGaming.TibiaAPI.Network.ServerPackets
             {
                 message.Write(TotalTibiaCoins);
                 message.Write(TransferableTibiaCoins);
+                if (Client.VersionNumber >= 125010109)
+                {
+                    message.Write(Unknown);
+                }
                 if (Client.VersionNumber >= 12158493)
                 {
                     message.Write(TournamentCoins);

--- a/TibiaAPI/Network/ServerPackets/SessionDumpStart.cs
+++ b/TibiaAPI/Network/ServerPackets/SessionDumpStart.cs
@@ -1,0 +1,24 @@
+﻿using OXGaming.TibiaAPI.Constants;
+
+namespace OXGaming.TibiaAPI.Network.ServerPackets
+{
+    public class SessionDumpStart : ServerPacket
+    {
+        public SessionDumpStart(Client client)
+        {
+            Client = client;
+            PacketType = ServerPacketType.SessionDumpStart;
+        }
+
+        public override void ParseFromNetworkMessage(NetworkMessage message)
+        {
+            // TODO
+        }
+
+        public override void AppendToNetworkMessage(NetworkMessage message)
+        {
+            // TODO
+            // message.Write((byte)ServerPacketType.SessionDumpStart);
+        }
+    }
+}


### PR DESCRIPTION
How the character auction protocol works:
1. When you click the button in the Store to setup an auction, the client sends `CharacterTradeConfigurationAction` (0x76) packet with `Type` 0 followed by the same packet with `Type` 1. Because the client sends both back-to-back, and there's no other data with them, I'm assuming 0 is to tell the server the player wants to setup an auction, and 1 is to request character data. The server then responds with  `CharacterTradeConfiguration` (0x80) packet with `Type` 1 (list of your character's inventory and depot items), followed by the same packet with `Type` 2 (list of your character's store inbox items), followed by the same packet with `Type` 3 (list of various sales arguments you can add), then followed by the same packet with `Type` 0 (character name, level, etc. along with various requirements and if your character/account meets them).
2. If you meet all of the requirements, and proceed to the next step, the items, sales arguments, starting bid, and auction end date are all done client-sided; there is no data transmitted between the client and server from your actions.
3. Once you've setup your character auction and click "Next", the client send `CharacterTradeConfigurationAction` (0x76) packet with `Type` 2. This tells the server the starting bid, auction end date, and all the other options you selected in the previous screen. The server responds with `CharacterTradeConfiguration` (0x80) packet with `Type` 4. This tells the client your auction fee (as well as, currently, an unknown byte).
4. Once you've reviewed step 3 of the auction setup process, and you click "Confirm", the client sends `CharacterTradeConfigurationAction` (0x76) packet with `Type` 3. This tells the server the starting bid, auction end date, and various (currently) unknown values. The server then closes the connection with the client, and you are no longer able to login to that character (until you either abort the auction on the website, or the auction ends and there were no winning bids).